### PR TITLE
Use str.zfill() instead of str.rjust(.., '0') to be more explicit

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ def hotp(key, counter, digits=6, digest='sha1'):
     mac = hmac.new(key, counter, digest).digest()
     offset = mac[-1] & 0x0f
     binary = struct.unpack('>L', mac[offset:offset+4])[0] & 0x7fffffff
-    return str(binary)[-digits:].rjust(digits, '0')
+    return str(binary)[-digits:].zfill(digits)
 
 
 def totp(key, time_step=30, digits=6, digest='sha1'):

--- a/mintotp.py
+++ b/mintotp.py
@@ -13,7 +13,7 @@ def hotp(key, counter, digits=6, digest='sha1'):
     mac = hmac.new(key, counter, digest).digest()
     offset = mac[-1] & 0x0f
     binary = struct.unpack('>L', mac[offset:offset+4])[0] & 0x7fffffff
-    return str(binary)[-digits:].rjust(digits, '0')
+    return str(binary)[-digits:].zfill(digits)
 
 
 def totp(key, time_step=30, digits=6, digest='sha1'):


### PR DESCRIPTION
We are filling the string with possible leading zeroes so we can directly use
`str.zfill()` instead of `str.rjust(..., '0')`, the former IMHO is more explicit
and easier to read (and we save a couple of bytes too in both `README.md` and
`mintotp.py`!).

Except when there is a possible leading sign prefix (`+` or `-`) they
are equivalent.