### PR TITLE
Minimise lines used for importing

### DIFF
--- a/mintotp.py
+++ b/mintotp.py
@@ -1,11 +1,6 @@
 #!/usr/bin/env python3
 
-import base64
-import hmac
-import struct
-import sys
-import time
-
+import base64, hmac, struct, sys, time
 
 def hotp(key, counter, digits=6, digest='sha1'):
     key = base64.b32decode(key.upper() + '=' * ((8 - len(key)) % 8))


### PR DESCRIPTION
Replacing the current import code with a one line alternative would reduce the amount of lines in mintotp.py by four, to 16. In my experience it works exactly the same, unless I've missed any reason this wouldn't be done.