### PR TITLE
Improve key handling: strip and remove whitespace before generating TOTP

### DIFF
--- a/mintotp.py
+++ b/mintotp.py
@@ -23,7 +23,7 @@ def totp(key, time_step=30, digits=6, digest='sha1'):
 def main():
     args = [int(x) if x.isdigit() else x for x in sys.argv[1:]]
     for key in sys.stdin:
-        print(totp(key.strip(), *args))
+        print(totp(''.join(key.split()), *args))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Some users may paste TOTP secrets(from Google authenticator、Microsoft authenticator) with spaces for example:
"JXQ7 M3B5 YV4G 2NQK HWED 6TLP 3UCA R7FI".

This change adds two normalization steps:
- strip(): remove leading/trailing whitespace
- split()+join(): remove internal spaces